### PR TITLE
Delete the label removal Mergify rule

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,14 +10,6 @@ pull_request_rules:
         method: merge
         strict: smart
 
-  - name: Delete the merge-when-green label after merge
-    conditions:
-      - merged
-      - label=merge-when-green
-    actions:
-      label:
-        remove: [merge-when-green]
-
   - name: Delete the PR branch after merge
     conditions:
       - merged


### PR DESCRIPTION
It causes the previous rule (merge PRs that are ready) to re-check or
re-run and then fail/cancel because it doesn't match, because the label
isn't present.  So let's avoid having it look like our merged PRs are
red.