### PR TITLE
Add bintray resolver

### DIFF
--- a/docs/src/main/paradox/play/serving-grpc.md
+++ b/docs/src/main/paradox/play/serving-grpc.md
@@ -14,6 +14,7 @@ sbt
     ```scala
     // in project/plugins.sbt:
     addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "$akka.grpc.version$")
+    resolvers += Resolver.bintrayRepo("playframework", "maven")
     libraryDependencies += "com.lightbend.play" %% "play-grpc-generators" % "$project.version$"
     ```
     @@@


### PR DESCRIPTION
The dependency `play-grpc-generators` isn't located in maven central, it's located in https://dl.bintray.com/playframework/maven/