### PR TITLE
Fix the template for generating RouterUsingActions

### DIFF
--- a/play-generators/src/main/twirl/templates/PlayScala/RouterUsingActions.scala.txt
+++ b/play-generators/src/main/twirl/templates/PlayScala/RouterUsingActions.scala.txt
@@ -8,7 +8,7 @@ package @service.packageName
 
 import akka.annotation.InternalApi
 import akka.actor.ActorSystem
-import akka.grpc.GrpcServiceException
+import akka.grpc.{GrpcServiceException, Trailers}
 import play.grpc.internal.PlayRouterUsingActions
 import akka.grpc.scaladsl.GrpcExceptionHandler.defaultMapper
 import akka.http.scaladsl.model.Uri.Path
@@ -23,7 +23,7 @@ import scala.concurrent.ExecutionContext
   /**
    * Abstract base class for implementing @{serviceName} and using as a play Router
    */
-  abstract class Abstract@{serviceName}Router(mat: Materializer, system: ActorSystem, parsers: PlayBodyParsers, actionBuilder: ActionBuilder[Request, AnyContent], eHandler: ActorSystem => PartialFunction[Throwable, Status] = defaultMapper) extends PlayRouterUsingActions(mat, @{service.name}.name, parsers, actionBuilder) with @{serviceName} {
+  abstract class Abstract@{serviceName}Router(mat: Materializer, system: ActorSystem, parsers: PlayBodyParsers, actionBuilder: ActionBuilder[Request, AnyContent], eHandler: ActorSystem => PartialFunction[Throwable, Trailers] = defaultMapper) extends PlayRouterUsingActions(mat, @{service.name}.name, parsers, actionBuilder) with @{serviceName} {
 
     @{
       val (streamingInputMethods: Seq[String], unaryInputMethods: Seq[String]) = service.methods.partition(_.inputStreaming) match {
@@ -37,7 +37,7 @@ import scala.concurrent.ExecutionContext
      */
     @@InternalApi
     final override protected def createHandler(serviceName: String, mat: Materializer): RequestHeader => EssentialAction = {
-      val handler = @{serviceName}Handler(this, serviceName, eHandler)(mat, system)
+      val handler = @{serviceName}Handler(this, serviceName, eHandler)(system)
       reqOuter =>
         implicit val ec: ExecutionContext = mat.executionContext
         Path(reqOuter.path) match {


### PR DESCRIPTION
1. Modified the error handler type to `ActorSystem => PartialFunction[Throwable, Trailers]`
2. Removed the extra materializer being passed to ServiceHandler.

This fixes [issue](https://github.com/playframework/play-grpc/issues/292) for play-grpc version `0.8.2`