### PR TITLE
Create BuildInfo to make used versions available via plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,6 +110,12 @@ val playGenerators = Project("play-grpc-generators", file("play-generators"))
       Dependencies.Compile.akkaGrpcCodegen,
       Dependencies.Test.scalaTest,
     ),
+    buildInfoKeys ++= Seq[BuildInfoKey](organization, name, version, scalaVersion, sbtVersion),
+    buildInfoKeys += "akkaVersion"     → Dependencies.Versions.akka,
+    buildInfoKeys += "akkaGrpcVersion" → Dependencies.Versions.akkaGrpc,
+    buildInfoKeys += "akkaHttpVersion" → Dependencies.Versions.akkaHttp,
+    buildInfoKeys += "grpcVersion"     → Dependencies.Versions.grpc,
+    buildInfoPackage := "play.grpc.gen",
     // Only used in build tools (like sbt), so only 2.12 is needed:
     crossScalaVersions := Seq(scala212),
   )


### PR DESCRIPTION
The BuildInfo plugin was there already, but not configured to include relevant versions.