### PR TITLE
use fully qualified class name in generated module

### DIFF
--- a/play-generators/src/main/twirl/templates/PlayJava/AkkaGrpcClientModule.scala.txt
+++ b/play-generators/src/main/twirl/templates/PlayJava/AkkaGrpcClientModule.scala.txt
@@ -11,10 +11,6 @@ import play.inject.Binding;
 import play.inject.Module;
 import scala.collection.Seq;
 
-@services.map { service =>
-import @{service.packageName}.*;
-}
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -26,7 +22,7 @@ public class AkkaGrpcClientModule extends Module {
   public List<Binding<?>> bindings(play.Environment environment, Config config) {
     return Arrays.<Binding<?>>asList(
         @services.map { service =>
-           bindClass(@{service.name}Client.class).toProvider(@{service.name}ClientProvider.class)
+           bindClass(${service.packageName}.@{service.name}Client.class).toProvider(${service.packageName}.@{service.name}ClientProvider.class)
         }.mkString(",")
     );
   }

--- a/play-generators/src/main/twirl/templates/PlayJava/AkkaGrpcClientModule.scala.txt
+++ b/play-generators/src/main/twirl/templates/PlayJava/AkkaGrpcClientModule.scala.txt
@@ -22,7 +22,7 @@ public class AkkaGrpcClientModule extends Module {
   public List<Binding<?>> bindings(play.Environment environment, Config config) {
     return Arrays.<Binding<?>>asList(
         @services.map { service =>
-           bindClass(${service.packageName}.@{service.name}Client.class).toProvider(${service.packageName}.@{service.name}ClientProvider.class)
+           bindClass(@{service.packageName}.@{service.name}Client.class).toProvider(@{service.packageName}.@{service.name}ClientProvider.class)
         }.mkString(",")
     );
   }

--- a/play-generators/src/main/twirl/templates/PlayScala/AkkaGrpcClientModule.scala.txt
+++ b/play-generators/src/main/twirl/templates/PlayScala/AkkaGrpcClientModule.scala.txt
@@ -8,10 +8,6 @@
 
 import play.api.inject.Binding
 import play.api.{Configuration, Environment}
-@services.map { service =>
-import @{service.packageName}._
-}
-
 
 /**
  * Add this generated AkkaGrpcClientModule to play.modules.enabled
@@ -21,7 +17,7 @@ class AkkaGrpcClientModule extends play.api.inject.Module {
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
     Seq(
       @services.map { service =>
-        bind[@{service.name}Client].toProvider[@{service.name}ClientProvider]
+        bind[${service.packageName}.@{service.name}Client].toProvider[${service.packageName}.@{service.name}ClientProvider]
       }.mkString(",")
     )
   }

--- a/play-generators/src/main/twirl/templates/PlayScala/AkkaGrpcClientModule.scala.txt
+++ b/play-generators/src/main/twirl/templates/PlayScala/AkkaGrpcClientModule.scala.txt
@@ -17,7 +17,7 @@ class AkkaGrpcClientModule extends play.api.inject.Module {
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
     Seq(
       @services.map { service =>
-        bind[${service.packageName}.@{service.name}Client].toProvider[${service.packageName}.@{service.name}ClientProvider]
+        bind[@{service.packageName}.@{service.name}Client].toProvider[@{service.packageName}.@{service.name}ClientProvider]
       }.mkString(",")
     )
   }


### PR DESCRIPTION
- users on short lived upgrade paths sometimes need to maintain {versionN-1, versionN} clients in an application. currently they receive ambiguous import compile errors