### PR TITLE
Make PlayRouter.handler public

### DIFF
--- a/play-runtime/src/main/scala/play/grpc/internal/PlayRouter.scala
+++ b/play-runtime/src/main/scala/play/grpc/internal/PlayRouter.scala
@@ -68,7 +68,7 @@ import scala.compat.java8.FutureConverters._
    */
   protected val respond: HttpRequest => Future[HttpResponse]
 
-  private val handler = new AkkaHttpHandler {
+  val handler = new AkkaHttpHandler {
     override def apply(request: HttpRequest): Future[HttpResponse] = respond(request)
   }
 


### PR DESCRIPTION
Makes `PlayRouter.handler` public. This is to ease integration with Akka gRPC's [WebHandler](https://doc.akka.io/docs/akka-grpc/current/server/grpc-web.html). 

`WebHandler` needs access to an Akka Http's handler (`HttpRequest => Future[HttpResponse]`), but `PlayRouter` make it hard to access it. 

I don't see a strong reason to have this method as private, so I'm suggesting we just open it up.