### PR TITLE
Adding logback to eliminate a few warnings in Lagom tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -246,6 +246,7 @@ val lagomInteropTestScala = Project("lagom-grpc-interop-test-scala", file("lagom
       Dependencies.Test.akkaStreamTestkit,
       Dependencies.Test.junit,
       Dependencies.Test.scalaTest,
+      Dependencies.Test.logback,
     ),
   )
   .pluginTestingSettings
@@ -275,6 +276,7 @@ val lagomInteropTestJava = Project("lagom-grpc-interop-test-java", file("lagom-i
       Dependencies.Test.junit,
       Dependencies.Test.junitInterface,
       Dependencies.Test.scalaTest,
+      Dependencies.Test.logback,
     ),
   )
   .pluginTestingSettings

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,6 +75,7 @@ object Dependencies {
     val scalaTestPlusPlay = Compile.scalaTestPlusPlay % Test
 
     val junitInterface = "com.novocode" % "junit-interface" % "0.11" % "test"
+    val logback = "ch.qos.logback" % "logback-classic" % "1.2.11"
   }
 
 }


### PR DESCRIPTION
A few tests have warnings about being unable to find slf4j configs.  Adding logback to those subprojects fixes the issue.