### PR TITLE
Actually do publish play-generators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,7 @@ val playActionsTestData = Project("play-grpc-actions-testdata", file("play-actio
   .pluginTestingSettings
 
 val playGenerators = Project(id = "play-grpc-generators", file("play-generators"))
-  .enablePlugins(SbtTwirl, BuildInfoPlugin, build.play.grpc.NoPublish)
+  .enablePlugins(SbtTwirl, BuildInfoPlugin)
   .settings(
     libraryDependencies ++= Seq(
       Dependencies.Compile.akkaGrpcCodegen,


### PR DESCRIPTION
This line was added because of https://github.com/playframework/play-grpc/pull/415/files#r863258649
The reason to skip that project for publishing in `.travis.yml` can be found here: https://github.com/playframework/play-grpc/pull/236

However, now that we use `+publishSigned` (via sbt-ci-release) (instead of `++<scalaVersion>`) I think that should be fine now.