### PR TITLE
Group Scala Steward patch updates into single PR

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,14 +1,12 @@
 pullRequests.frequency = "@monthly"
+
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"
 
-updates.ignore = [
-  // explicit updates
-  { groupId = "org.scalameta", artifactId = "scalafmt-core" }
+pullRequests.grouping = [
+  { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] }
 ]
 
 updates.pin = [
   # Prevent updates to 3.2.x and beyond
   { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1."} 
 ]
-
-updatePullRequests = false


### PR DESCRIPTION
Patch updates are likey to not break anything so we can just put them into one PR.