### PR TITLE
Upgrade Play 2.9.0 and drop Java 8

### DIFF
--- a/.github/scala-steward.conf
+++ b/.github/scala-steward.conf
@@ -10,3 +10,5 @@ updates.pin = [
   # Prevent updates to 3.2.x and beyond
   { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1."} 
 ]
+
+updatePullRequests = false

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,7 +38,7 @@ jobs:
       - "check-docs"
     uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
-      java: 11, 8
+      java: 17, 11
       scala: 2.12.x, 2.13.x
       cmd: sbt ++$MATRIX_SCALA test
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,14 +15,14 @@ concurrency:
 jobs:
   check-code-style:
     name: Code Style
-    uses: playframework/.github/.github/workflows/cmd.yml@v3
+    uses: playframework/.github/.github/workflows/cmd.yml@v3.4.0
     with:
       cmd: sbt scalafmtCheckAll scalafmtSbtCheck javafmtCheckAll headerCheckAll
 
 #  MiMa is not enabled yet, since this library is marked as "API may change".
 #  check-binary-compatibility:
 #    name: Binary Compatibility
-#    uses: playframework/.github/.github/workflows/binary-check.yml@v3
+#    uses: playframework/.github/.github/workflows/binary-check.yml@v3.4.0
 
   check-docs:
     name: Docs
@@ -36,7 +36,7 @@ jobs:
       - "check-code-style"
       # - "check-binary-compatibility"
       - "check-docs"
-    uses: playframework/.github/.github/workflows/cmd.yml@v3
+    uses: playframework/.github/.github/workflows/cmd.yml@v3.4.0
     with:
       java: 17, 11
       scala: 2.13.x
@@ -47,4 +47,4 @@ jobs:
     if: github.event_name == 'pull_request'
     needs: # Should be last
       - "tests"
-    uses: playframework/.github/.github/workflows/rtm.yml@v3
+    uses: playframework/.github/.github/workflows/rtm.yml@v3.4.0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,7 +39,7 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 17, 11
-      scala: 2.12.x, 2.13.x
+      scala: 2.13.x
       cmd: sbt ++$MATRIX_SCALA test
 
   finish:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,14 +15,14 @@ concurrency:
 jobs:
   check-code-style:
     name: Code Style
-    uses: playframework/.github/.github/workflows/cmd.yml@v3.4.0
+    uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       cmd: sbt scalafmtCheckAll scalafmtSbtCheck javafmtCheckAll headerCheckAll
 
 #  MiMa is not enabled yet, since this library is marked as "API may change".
 #  check-binary-compatibility:
 #    name: Binary Compatibility
-#    uses: playframework/.github/.github/workflows/binary-check.yml@v3.4.0
+#    uses: playframework/.github/.github/workflows/binary-check.yml@v3
 
   check-docs:
     name: Docs
@@ -36,7 +36,7 @@ jobs:
       - "check-code-style"
       # - "check-binary-compatibility"
       - "check-docs"
-    uses: playframework/.github/.github/workflows/cmd.yml@v3.4.0
+    uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 17, 11
       scala: 2.13.x
@@ -47,4 +47,4 @@ jobs:
     if: github.event_name == 'pull_request'
     needs: # Should be last
       - "tests"
-    uses: playframework/.github/.github/workflows/rtm.yml@v3.4.0
+    uses: playframework/.github/.github/workflows/rtm.yml@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,5 +9,5 @@ on:
 jobs:
   publish-artifacts:
     name: Publish / Artifacts
-    uses: playframework/.github/.github/workflows/publish.yml@v3
+    uses: playframework/.github/.github/workflows/publish.yml@v3.4.0
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,5 +9,5 @@ on:
 jobs:
   publish-artifacts:
     name: Publish / Artifacts
-    uses: playframework/.github/.github/workflows/publish.yml@v3.4.0
+    uses: playframework/.github/.github/workflows/publish.yml@v3
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,5 +9,5 @@ on:
 jobs:
   publish-artifacts:
     name: Publish / Artifacts
-    uses: playframework/.github/.github/workflows/publish.yml@v2
+    uses: playframework/.github/.github/workflows/publish.yml@v3
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 node_modules/
 /docs/build/
 /docs/package*.json
+logs/

--- a/build.sbt
+++ b/build.sbt
@@ -116,6 +116,7 @@ val playGenerators = Project(id = "play-grpc-generators", file("play-generators"
     buildInfoPackage                  := "play.grpc.gen",
     // Only used in build tools (like sbt), so only 2.12 is needed:
     crossScalaVersions := Seq(scala212),
+    scalaVersion := scala212,
   )
 
 val playTestkit = Project("play-grpc-testkit", file("play-testkit"))

--- a/build.sbt
+++ b/build.sbt
@@ -212,6 +212,4 @@ val playInteropTestJava = Project("play-grpc-interop-test-java", file("play-inte
   .enablePlugins(build.play.grpc.NoPublish)
   .pluginTestingSettings
 
-Test / javaOptions ++= Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED")
-
 Global / cancelable := true

--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,7 @@ val playGenerators = Project(id = "play-grpc-generators", file("play-generators"
     buildInfoPackage                  := "play.grpc.gen",
     // Only used in build tools (like sbt), so only 2.12 is needed:
     crossScalaVersions := Seq(scala212),
-    scalaVersion := scala212,
+    scalaVersion       := scala212,
   )
 
 val playTestkit = Project("play-grpc-testkit", file("play-testkit"))

--- a/build.sbt
+++ b/build.sbt
@@ -212,4 +212,23 @@ val playInteropTestJava = Project("play-grpc-interop-test-java", file("play-inte
   .enablePlugins(build.play.grpc.NoPublish)
   .pluginTestingSettings
 
+val docs = Project("play-grpc-docs", file("docs"))
+  .enablePlugins(AkkaParadoxPlugin)
+  .settings(
+    // Make sure code generation is run before paradox:
+    (Compile / paradox) := (Compile / paradox).dependsOn(Compile / compile).value,
+    paradoxGroups := Map(
+      "Language"  -> Seq("Scala", "Java"),
+      "Buildtool" -> Seq("sbt", "Gradle", "Maven"),
+    ),
+    paradoxProperties ++= Map(
+      "grpc.version"      -> Dependencies.Versions.grpc,
+      "akka.grpc.version" -> Dependencies.Versions.akkaGrpc,
+    ),
+    resolvers += Resolver.jcenterRepo,
+  )
+  .enablePlugins(build.play.grpc.NoPublish)
+
+Test / javaOptions ++= Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED")
+
 Global / cancelable := true

--- a/build.sbt
+++ b/build.sbt
@@ -212,23 +212,6 @@ val playInteropTestJava = Project("play-grpc-interop-test-java", file("play-inte
   .enablePlugins(build.play.grpc.NoPublish)
   .pluginTestingSettings
 
-val docs = Project("play-grpc-docs", file("docs"))
-  .enablePlugins(AkkaParadoxPlugin)
-  .settings(
-    // Make sure code generation is run before paradox:
-    (Compile / paradox) := (Compile / paradox).dependsOn(Compile / compile).value,
-    paradoxGroups := Map(
-      "Language"  -> Seq("Scala", "Java"),
-      "Buildtool" -> Seq("sbt", "Gradle", "Maven"),
-    ),
-    paradoxProperties ++= Map(
-      "grpc.version"      -> Dependencies.Versions.grpc,
-      "akka.grpc.version" -> Dependencies.Versions.akkaGrpc,
-    ),
-    resolvers += Resolver.jcenterRepo,
-  )
-  .enablePlugins(build.play.grpc.NoPublish)
-
 Test / javaOptions ++= Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED")
 
 Global / cancelable := true

--- a/play-scalatest/src/main/scala/play/grpc/scalatest/ServerGrpcClient.scala
+++ b/play-scalatest/src/main/scala/play/grpc/scalatest/ServerGrpcClient.scala
@@ -27,8 +27,4 @@ trait ServerGrpcClient extends AkkaGrpcClientHelpers { this: BaseOneServerPerTes
   ): AkkaGrpcClientFactory.Configured[T] = {
     AkkaGrpcClientHelpers.factoryForAppEndpoints(running.app, running.endpoints)
   }
-
-  protected override def newServerForTest(app: Application, testData: TestData): RunningServer =
-    DefaultTestServerFactory.start(app)
-
 }

--- a/play-scalatest/src/test/resources/application.conf
+++ b/play-scalatest/src/test/resources/application.conf
@@ -1,0 +1,1 @@
+play.ws.ssl.loose.acceptAnyCertificate = true

--- a/play-scalatest/src/test/resources/logback.xml
+++ b/play-scalatest/src/test/resources/logback.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
+
+<!DOCTYPE configuration>
+
+<configuration>
+  <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+  <import class="ch.qos.logback.classic.AsyncAppender"/>
+  <import class="ch.qos.logback.core.FileAppender"/>
+  <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+  <appender name="FILE" class="FileAppender">
+    <file>${application.home:-.}/logs/application.log</file>
+    <encoder class="PatternLayoutEncoder">
+      <charset>UTF-8</charset>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{pekkoSource}) %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ConsoleAppender">
+    <!--
+         On Windows, enabling Jansi is recommended to benefit from color code interpretation on DOS command prompts,
+         which otherwise risk being sent ANSI escape sequences that they cannot interpret.
+         See https://logback.qos.ch/manual/layouts.html#coloring
+    -->
+    <!-- <withJansi>true</withJansi> -->
+    <encoder class="PatternLayoutEncoder">
+      <charset>UTF-8</charset>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{pekkoSource}) %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNCFILE" class="AsyncAppender">
+    <appender-ref ref="FILE"/>
+  </appender>
+
+  <appender name="ASYNCSTDOUT" class="AsyncAppender">
+    <appender-ref ref="STDOUT"/>
+  </appender>
+
+  <logger name="play" level="INFO"/>
+  <logger name="application" level="DEBUG"/>
+
+  <root level="WARN">
+    <appender-ref ref="ASYNCFILE"/>
+    <appender-ref ref="ASYNCSTDOUT"/>
+  </root>
+
+</configuration>

--- a/play-scalatest/src/test/scala/play/grpc/scalatest/PlayActionsScalaTestSpec.scala
+++ b/play-scalatest/src/test/scala/play/grpc/scalatest/PlayActionsScalaTestSpec.scala
@@ -39,7 +39,7 @@ class PlayActionsScalaTestSpec
 
   "A Play server bound to a gRPC router using actions" must {
     "give a 404 when routing a non-gRPC request" in {
-      val result = wsUrl("/").get.futureValue
+      val result = wsUrl("/", true).get.futureValue
       result.status must be(404) // Maybe should be a 426, see #396
     }
     // this test results in a 500
@@ -57,7 +57,7 @@ class PlayActionsScalaTestSpec
     //   result.header("grpc-status") mustEqual Some(Status.Code.UNIMPLEMENTED.value().toString)
     // }
     "give a grpc 'invalid argument' error when routing an empty request to a gRPC method" in {
-      val result = wsUrl(s"/${GreeterService.name}/SayHello")
+      val result = wsUrl(s"/${GreeterService.name}/SayHello", true)
         .addHttpHeaders("Content-Type" -> GrpcProtocolNative.contentType.toString)
         .get
         .futureValue

--- a/play-scalatest/src/test/scala/play/grpc/scalatest/PlayActionsScalaTestSpec.scala
+++ b/play-scalatest/src/test/scala/play/grpc/scalatest/PlayActionsScalaTestSpec.scala
@@ -15,6 +15,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WSClient
 import play.api.routing.Router
 import play.api.Application
+import play.grpc.testkit.SslTestServerFactory
 
 /**
  * Test for the Play gRPC ScalaTest APIs
@@ -25,6 +26,8 @@ class PlayActionsScalaTestSpec
     with ServerGrpcClient
     with ScalaFutures
     with IntegrationPatience {
+
+  override def testServerFactory = new SslTestServerFactory
 
   override def fakeApplication(): Application = {
     GuiceApplicationBuilder()

--- a/play-scalatest/src/test/scala/play/grpc/scalatest/PlayScalaTestSpec.scala
+++ b/play-scalatest/src/test/scala/play/grpc/scalatest/PlayScalaTestSpec.scala
@@ -15,6 +15,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WSClient
 import play.api.routing.Router
 import play.api.Application
+import play.grpc.testkit.SslTestServerFactory
 
 /**
  * Test for the Play gRPC ScalaTest APIs
@@ -25,6 +26,8 @@ class PlayScalaTestSpec
     with ServerGrpcClient
     with ScalaFutures
     with IntegrationPatience {
+
+  override def testServerFactory = new SslTestServerFactory
 
   override def fakeApplication(): Application = {
     GuiceApplicationBuilder()

--- a/play-scalatest/src/test/scala/play/grpc/scalatest/PlayScalaTestSpec.scala
+++ b/play-scalatest/src/test/scala/play/grpc/scalatest/PlayScalaTestSpec.scala
@@ -39,15 +39,15 @@ class PlayScalaTestSpec
 
   "A Play server bound to a gRPC router" must {
     "give a 404 when routing a non-gRPC request" in {
-      val result = wsUrl("/").get.futureValue
+      val result = wsUrl("/", true).get.futureValue
       result.status must be(404) // Maybe should be a 426, see #396
     }
     "give a 415 error when not using a gRPC content-type" in {
-      val result = wsUrl(s"/${GreeterService.name}/FooBar").get.futureValue
+      val result = wsUrl(s"/${GreeterService.name}/FooBar", true).get.futureValue
       result.status must be(415)
     }
     "give a grpc 'unimplemented' error when routing a non-existent gRPC method" in {
-      val result = wsUrl(s"/${GreeterService.name}/FooBar")
+      val result = wsUrl(s"/${GreeterService.name}/FooBar", true)
         .addHttpHeaders("Content-Type" -> GrpcProtocolNative.contentType.toString)
         .get
         .futureValue
@@ -55,7 +55,7 @@ class PlayScalaTestSpec
       result.header("grpc-status") mustEqual Some(Status.Code.UNIMPLEMENTED.value().toString)
     }
     "give a grpc 'invalid argument' error when routing an empty request to a gRPC method" in {
-      val result = wsUrl(s"/${GreeterService.name}/SayHello")
+      val result = wsUrl(s"/${GreeterService.name}/SayHello", true)
         .addHttpHeaders("Content-Type" -> GrpcProtocolNative.contentType.toString)
         .get
         .futureValue

--- a/play-specs2/src/test/resources/application.conf
+++ b/play-specs2/src/test/resources/application.conf
@@ -1,0 +1,1 @@
+play.ws.ssl.loose.acceptAnyCertificate = true

--- a/play-specs2/src/test/resources/logback.xml
+++ b/play-specs2/src/test/resources/logback.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
+
+<!DOCTYPE configuration>
+
+<configuration>
+  <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+  <import class="ch.qos.logback.classic.AsyncAppender"/>
+  <import class="ch.qos.logback.core.FileAppender"/>
+  <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+  <appender name="FILE" class="FileAppender">
+    <file>${application.home:-.}/logs/application.log</file>
+    <encoder class="PatternLayoutEncoder">
+      <charset>UTF-8</charset>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{pekkoSource}) %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ConsoleAppender">
+    <!--
+         On Windows, enabling Jansi is recommended to benefit from color code interpretation on DOS command prompts,
+         which otherwise risk being sent ANSI escape sequences that they cannot interpret.
+         See https://logback.qos.ch/manual/layouts.html#coloring
+    -->
+    <!-- <withJansi>true</withJansi> -->
+    <encoder class="PatternLayoutEncoder">
+      <charset>UTF-8</charset>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{pekkoSource}) %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNCFILE" class="AsyncAppender">
+    <appender-ref ref="FILE"/>
+  </appender>
+
+  <appender name="ASYNCSTDOUT" class="AsyncAppender">
+    <appender-ref ref="STDOUT"/>
+  </appender>
+
+  <logger name="play" level="INFO"/>
+  <logger name="application" level="DEBUG"/>
+
+  <root level="WARN">
+    <appender-ref ref="ASYNCFILE"/>
+    <appender-ref ref="ASYNCSTDOUT"/>
+  </root>
+
+</configuration>

--- a/play-specs2/src/test/scala/play/grpc/specs2/PlaySpecs2Spec.scala
+++ b/play-specs2/src/test/scala/play/grpc/specs2/PlaySpecs2Spec.scala
@@ -30,7 +30,7 @@ class PlaySpecs2Spec extends ForServer with ServerGrpcClient with PlaySpecificat
   // RICH: Still need to work out how to make WSClient work properly with endpoints
   def wsUrl(path: String)(implicit running: RunningServer): WSRequest = {
     val ws  = running.app.injector.instanceOf[WSClient]
-    val url = running.endpoints.httpEndpoint.get.pathUrl(path)
+    val url = running.endpoints.httpsEndpoint.get.pathUrl(path)
     ws.url(url)
   }
 

--- a/play-specs2/src/test/scala/play/grpc/specs2/PlaySpecs2Spec.scala
+++ b/play-specs2/src/test/scala/play/grpc/specs2/PlaySpecs2Spec.scala
@@ -14,12 +14,15 @@ import play.api.libs.ws.WSClient
 import play.api.libs.ws.WSRequest
 import play.api.routing.Router
 import play.api.test._
+import play.grpc.testkit.SslTestServerFactory
 
 /**
  * Test for the Play gRPC Specs2 APIs
  */
 @RunWith(classOf[JUnitRunner])
 class PlaySpecs2Spec extends ForServer with ServerGrpcClient with PlaySpecification with ApplicationFactories {
+
+  override def testServerFactory = new SslTestServerFactory
 
   protected def applicationFactory: ApplicationFactory =
     withGuiceApp(GuiceApplicationBuilder().overrides(bind[Router].to[GreeterServiceImpl]))

--- a/play-testkit/src/main/java/play/grpc/testkit/JavaAkkaGrpcClientHelpers.java
+++ b/play-testkit/src/main/java/play/grpc/testkit/JavaAkkaGrpcClientHelpers.java
@@ -31,7 +31,7 @@ public final class JavaAkkaGrpcClientHelpers {
             .endpoints()
             .filter(e -> e.protocols().contains("HTTP/2.0" /* Play's HttpProtocol.HTTP_2_0 */))
             .toIterable();
-    if (possibleEndpoints.size() == 0) {
+    if (possibleEndpoints.isEmpty()) {
       throw new IllegalArgumentException(
           String.format(
               "gRPC client can't automatically find HTTP/2 connection: "

--- a/play-testkit/src/main/java/play/grpc/testkit/JavaAkkaGrpcClientHelpers.java
+++ b/play-testkit/src/main/java/play/grpc/testkit/JavaAkkaGrpcClientHelpers.java
@@ -60,7 +60,7 @@ public final class JavaAkkaGrpcClientHelpers {
             .getOrElse(
                 () -> {
                   throw new IllegalArgumentException(
-                      "GrpcClientSettings requires a server endpoint with ssl, but non provided");
+                      "GrpcClientSettings requires a server endpoint with ssl, but none provided");
                 });
 
     return grpcClientSettings(http2Endpoint, sslContext, actorSystem);

--- a/play-testkit/src/test/java/play/grpc/testkit/PlayJavaFunctionalTest.java
+++ b/play-testkit/src/test/java/play/grpc/testkit/PlayJavaFunctionalTest.java
@@ -19,7 +19,7 @@ import play.inject.guice.*;
 import play.libs.ws.*;
 
 public final class PlayJavaFunctionalTest {
-  private final TestServerFactory testServerFactory = new DefaultTestServerFactory();
+  private final TestServerFactory testServerFactory = new SslTestServerFactory();
 
   private Application app;
   private RunningServer runningServer;
@@ -49,7 +49,7 @@ public final class PlayJavaFunctionalTest {
 
   private WSResponse wsGet(final String path) throws Exception {
     final WSClient wsClient = app.injector().instanceOf(WSClient.class);
-    final String url = runningServer.endpoints().httpEndpoint().get().pathUrl(path);
+    final String url = runningServer.endpoints().httpsEndpoint().get().pathUrl(path);
     return wsClient
         .url(url)
         .addHeader("Content-Type", GrpcProtocolNative.contentType().toString())

--- a/play-testkit/src/test/resources/application.conf
+++ b/play-testkit/src/test/resources/application.conf
@@ -1,1 +1,3 @@
 play.server.provider = play.core.server.AkkaHttpServerProvider
+
+play.ws.ssl.loose.acceptAnyCertificate = true

--- a/play-testkit/src/test/resources/logback.xml
+++ b/play-testkit/src/test/resources/logback.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
+
+<!DOCTYPE configuration>
+
+<configuration>
+  <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+  <import class="ch.qos.logback.classic.AsyncAppender"/>
+  <import class="ch.qos.logback.core.FileAppender"/>
+  <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+  <appender name="FILE" class="FileAppender">
+    <file>${application.home:-.}/logs/application.log</file>
+    <encoder class="PatternLayoutEncoder">
+      <charset>UTF-8</charset>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{pekkoSource}) %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ConsoleAppender">
+    <!--
+         On Windows, enabling Jansi is recommended to benefit from color code interpretation on DOS command prompts,
+         which otherwise risk being sent ANSI escape sequences that they cannot interpret.
+         See https://logback.qos.ch/manual/layouts.html#coloring
+    -->
+    <!-- <withJansi>true</withJansi> -->
+    <encoder class="PatternLayoutEncoder">
+      <charset>UTF-8</charset>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{pekkoSource}) %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNCFILE" class="AsyncAppender">
+    <appender-ref ref="FILE"/>
+  </appender>
+
+  <appender name="ASYNCSTDOUT" class="AsyncAppender">
+    <appender-ref ref="STDOUT"/>
+  </appender>
+
+  <logger name="play" level="INFO"/>
+  <logger name="application" level="DEBUG"/>
+
+  <root level="WARN">
+    <appender-ref ref="ASYNCFILE"/>
+    <appender-ref ref="ASYNCSTDOUT"/>
+  </root>
+
+</configuration>

--- a/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
+++ b/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
@@ -16,8 +16,8 @@ import play.core.server.ServerConfig
     super
       .serverConfig(app)
       .copy(
-        port = None,       // disables http port (or use Some(0) for a random port or for a fixed port e.g. 9001 Some(9001))
-        sslPort = Some(0), // Using 0 a random port from the operating system will be assigned
+        port = None,
+        sslPort = Some(0),
       )
   }
 }

--- a/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
+++ b/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
@@ -4,8 +4,8 @@
 package play.grpc.testkit
 
 import akka.annotation.ApiMayChange
-import play.api.Application
 import play.api.test.DefaultTestServerFactory
+import play.api.Application
 import play.core.server.ServerConfig
 
 /**

--- a/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
+++ b/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
@@ -18,8 +18,8 @@ import play.core.server.ServerConfig
     super
       .serverConfig(app)
       .copy(
-        port = None,      // disables http port (or use Some(0) for a random port or for a fixed port e.g. 9001 Some(9001))
-        sslPort = Some(0),// Using 0 a random port from the operating system will be assigned
+        port = None,       // disables http port (or use Some(0) for a random port or for a fixed port e.g. 9001 Some(9001))
+        sslPort = Some(0), // Using 0 a random port from the operating system will be assigned
       )
   }
 }

--- a/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
+++ b/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package play.grpc.testkit
 
 import akka.annotation.ApiMayChange

--- a/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
+++ b/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
@@ -1,16 +1,24 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package play.grpc.testkit
 
+import akka.annotation.ApiMayChange
 import play.api.Application
 import play.api.test.DefaultTestServerFactory
 import play.core.server.ServerConfig
 
-class SslTestServerFactory extends DefaultTestServerFactory {
+/**
+ * A test server factory that configures the server to use SSL.
+ */
+@ApiMayChange class SslTestServerFactory extends DefaultTestServerFactory {
   override def serverConfig(app: Application): ServerConfig = {
     super
       .serverConfig(app)
       .copy(
-        port = None,      // disables http port (or use Some(0) for a random port or for a fixed port e.g. 9001 Some(9001))
-        sslPort = Some(0),// Using 0 a random port from the operating system will be assigned
+        port = None,       // disables http port (or use Some(0) for a random port or for a fixed port e.g. 9001 Some(9001))
+        sslPort = Some(0), // Using 0 a random port from the operating system will be assigned
       )
   }
 }

--- a/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
+++ b/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
@@ -4,9 +4,8 @@
 package play.grpc.testkit
 
 import akka.annotation.ApiMayChange
-
-import play.api.Application
 import play.api.test.DefaultTestServerFactory
+import play.api.Application
 import play.core.server.ServerConfig
 
 /**

--- a/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
+++ b/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
@@ -17,8 +17,8 @@ import play.core.server.ServerConfig
     super
       .serverConfig(app)
       .copy(
-        port = None,       // disables http port (or use Some(0) for a random port or for a fixed port e.g. 9001 Some(9001))
-        sslPort = Some(0), // Using 0 a random port from the operating system will be assigned
+        port = None,
+        sslPort = Some(0),
       )
   }
 }

--- a/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
+++ b/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
@@ -1,11 +1,13 @@
 /*
  * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.grpc.testkit
 
 import akka.annotation.ApiMayChange
-import play.api.test.DefaultTestServerFactory
+
 import play.api.Application
+import play.api.test.DefaultTestServerFactory
 import play.core.server.ServerConfig
 
 /**
@@ -16,8 +18,8 @@ import play.core.server.ServerConfig
     super
       .serverConfig(app)
       .copy(
-        port = None,
-        sslPort = Some(0),
+        port = None,      // disables http port (or use Some(0) for a random port or for a fixed port e.g. 9001 Some(9001))
+        sslPort = Some(0),// Using 0 a random port from the operating system will be assigned
       )
   }
 }

--- a/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
+++ b/play-testkit/src/test/scala/play/grpc/testkit/SslTestServerFactory.scala
@@ -1,0 +1,16 @@
+package play.grpc.testkit
+
+import play.api.Application
+import play.api.test.DefaultTestServerFactory
+import play.core.server.ServerConfig
+
+class SslTestServerFactory extends DefaultTestServerFactory {
+  override def serverConfig(app: Application): ServerConfig = {
+    super
+      .serverConfig(app)
+      .copy(
+        port = None,      // disables http port (or use Some(0) for a random port or for a fixed port e.g. 9001 Some(9001))
+        sslPort = Some(0),// Using 0 a random port from the operating system will be assigned
+      )
+  }
+}

--- a/project/CommonPlugin.scala
+++ b/project/CommonPlugin.scala
@@ -18,6 +18,8 @@ object CommonPlugin extends AutoPlugin {
         Nil
     },
     doc / javacOptions --= Seq("-Xlint:unchecked", "-Xlint:deprecation"),
+    Test / javaOptions ++= Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED"),
+    Test / fork        := true,
     crossScalaVersions := Seq(scala213),
     scalaVersion       := scala213,
   )

--- a/project/CommonPlugin.scala
+++ b/project/CommonPlugin.scala
@@ -18,7 +18,8 @@ object CommonPlugin extends AutoPlugin {
         Nil
     },
     doc / javacOptions --= Seq("-Xlint:unchecked", "-Xlint:deprecation"),
-    crossScalaVersions := Seq(scala212, scala213),
+    crossScalaVersions := Seq(scala213),
+    scalaVersion := scala213,
   )
 
   val scalaVersionNumber = Def.setting(VersionNumber(scalaVersion.value))

--- a/project/CommonPlugin.scala
+++ b/project/CommonPlugin.scala
@@ -19,7 +19,7 @@ object CommonPlugin extends AutoPlugin {
     },
     doc / javacOptions --= Seq("-Xlint:unchecked", "-Xlint:deprecation"),
     crossScalaVersions := Seq(scala213),
-    scalaVersion := scala213,
+    scalaVersion       := scala213,
   )
 
   val scalaVersionNumber = Def.setting(VersionNumber(scalaVersion.value))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
 
     val play = "2.9.1"
 
-    val scalaTest         = "3.2.14"
+    val scalaTest         = "3.2.17"
     val scalaTestPlusPlay = "6.0.0"
 
     val macwire = "2.5.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     val akkaHttp = "10.2.10"
 
     val akkaGrpc: String = AkkaGrpcBuildInfo.version
-    val grpc: String = AkkaGrpcBuildInfo.grpcVersion
+    val grpc: String     = AkkaGrpcBuildInfo.grpcVersion
 
     val play = "2.9.1"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
     val play = "2.9.1"
 
     val scalaTest         = "3.2.17"
-    val scalaTestPlusPlay = "5.1.0"
+    val scalaTestPlusPlay = "6.0.0"
 
     val macwire = "2.5.9"
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
     val play = "2.9.1"
 
     val scalaTest         = "3.2.17"
-    val scalaTestPlusPlay = "6.0.0"
+    val scalaTestPlusPlay = "5.1.0"
 
     val macwire = "2.5.9"
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
     val play = "2.9.1"
 
     val scalaTest         = "3.2.17"
-    val scalaTestPlusPlay = "6.0.0"
+    val scalaTestPlusPlay = "6.0.1"
 
     val macwire = "2.5.9"
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val akkaGrpc = AkkaGrpcBuildInfo.version
     val grpc     = AkkaGrpcBuildInfo.grpcVersion
 
-    val play  = "2.9.0-M2"
+    val play = "2.9.0-M2"
 
     val scalaTest         = "3.2.14"
     val scalaTestPlusPlay = "6.0.0-M1"
@@ -74,7 +74,7 @@ object Dependencies {
     val scalaTestPlusPlay = Compile.scalaTestPlusPlay % Test
 
     val junitInterface = "com.github.sbt" % "junit-interface" % "0.13.3" % "test"
-    val logback        = "ch.qos.logback" % "logback-classic" % "1.4.4" % "test"
+    val logback        = "ch.qos.logback" % "logback-classic" % "1.4.4"  % "test"
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,10 +20,10 @@ object Dependencies {
     val akkaGrpc = AkkaGrpcBuildInfo.version
     val grpc     = AkkaGrpcBuildInfo.grpcVersion
 
-    val play = "2.9.0-M2"
+    val play = "2.9.1"
 
     val scalaTest         = "3.2.14"
-    val scalaTestPlusPlay = "6.0.0-M1"
+    val scalaTestPlusPlay = "6.0.0"
 
     val macwire = "2.5.9"
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
 
     val play  = "2.9.0-M2"
 
-    val scalaTest         = "3.1.4"
+    val scalaTest         = "3.2.14"
     val scalaTestPlusPlay = "6.0.0-M1"
 
     val macwire = "2.5.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,7 +74,7 @@ object Dependencies {
     val scalaTestPlusPlay = Compile.scalaTestPlusPlay % Test
 
     val junitInterface = "com.github.sbt" % "junit-interface" % "0.13.3" % "test"
-    val logback        = "ch.qos.logback" % "logback-classic" % "1.2.12" % "test"
+    val logback        = "ch.qos.logback" % "logback-classic" % "1.4.4" % "test"
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,7 +74,6 @@ object Dependencies {
     val scalaTestPlusPlay = Compile.scalaTestPlusPlay % Test
 
     val junitInterface = "com.github.sbt" % "junit-interface" % "0.13.3" % "test"
-    val logback        = "ch.qos.logback" % "logback-classic" % "1.4.4"  % "test"
+    val logback        = "ch.qos.logback" % "logback-classic" % "1.4.14" % "test"
   }
-
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
     val play  = "2.9.0-M2"
 
     val scalaTest         = "3.1.4"
-    val scalaTestPlusPlay = "5.1.0"
+    val scalaTestPlusPlay = "6.0.0-M1"
 
     val macwire = "2.5.9"
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val akkaGrpc = AkkaGrpcBuildInfo.version
     val grpc     = AkkaGrpcBuildInfo.grpcVersion
 
-    val play = "2.8.21"
+    val play  = "2.9.0-M2"
 
     val scalaTest         = "3.1.4"
     val scalaTestPlusPlay = "5.1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,8 +17,8 @@ object Dependencies {
     // bumps Akka HTTP version beyond play's 10.1.x
     val akkaHttp = "10.2.10"
 
-    val akkaGrpc = AkkaGrpcBuildInfo.version
-    val grpc     = AkkaGrpcBuildInfo.grpcVersion
+    val akkaGrpc: String = AkkaGrpcBuildInfo.version
+    val grpc: String = AkkaGrpcBuildInfo.grpcVersion
 
     val play = "2.9.1"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,5 @@ addSbtPlugin("com.typesafe.play"       % "sbt-twirl"          % "1.6.4")
 addSbtPlugin("de.heikoseeberger"       % "sbt-header"         % "5.10.0")
 addSbtPlugin("org.scalameta"           % "sbt-scalafmt"       % "2.5.2")
 addSbtPlugin("com.lightbend.sbt"       % "sbt-java-formatter" % "0.8.0")
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc"      % "2.1.6") // Sync with docs/antora.yml
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc"      % "2.1.5") // Sync with docs/antora.yml
 addSbtPlugin("com.github.sbt"          % "sbt-ci-release"     % "1.5.12")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.eed3si9n"            % "sbt-buildinfo"      % "0.11.0")
 addSbtPlugin("com.lightbend.akka"      % "sbt-paradox-akka"   % "0.44")
 addSbtPlugin("com.typesafe.play"       % "sbt-twirl"          % "1.6.4")
 addSbtPlugin("de.heikoseeberger"       % "sbt-header"         % "5.10.0")
-addSbtPlugin("org.scalameta"           % "sbt-scalafmt"       % "2.5.1")
+addSbtPlugin("org.scalameta"           % "sbt-scalafmt"       % "2.5.2")
 addSbtPlugin("com.lightbend.sbt"       % "sbt-java-formatter" % "0.8.0")
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc"      % "2.1.5") // Sync with docs/antora.yml
 addSbtPlugin("com.github.sbt"          % "sbt-ci-release"     % "1.5.12")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,5 @@ addSbtPlugin("com.typesafe.play"       % "sbt-twirl"          % "1.6.4")
 addSbtPlugin("de.heikoseeberger"       % "sbt-header"         % "5.10.0")
 addSbtPlugin("org.scalameta"           % "sbt-scalafmt"       % "2.5.2")
 addSbtPlugin("com.lightbend.sbt"       % "sbt-java-formatter" % "0.8.0")
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc"      % "2.1.5") // Sync with docs/antora.yml
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc"      % "2.1.6") // Sync with docs/antora.yml
 addSbtPlugin("com.github.sbt"          % "sbt-ci-release"     % "1.5.12")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.eed3si9n"            % "sbt-buildinfo"      % "0.11.0")
 addSbtPlugin("com.lightbend.akka"      % "sbt-paradox-akka"   % "0.44")
-addSbtPlugin("com.typesafe.sbt"        % "sbt-twirl"          % "1.5.1")
+addSbtPlugin("com.typesafe.play"       % "sbt-twirl"          % "1.6.4")
 addSbtPlugin("de.heikoseeberger"       % "sbt-header"         % "5.10.0")
 addSbtPlugin("org.scalameta"           % "sbt-scalafmt"       % "2.5.1")
 addSbtPlugin("com.lightbend.sbt"       % "sbt-java-formatter" % "0.8.0")

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -1,7 +1,7 @@
 project-info {
   # version is overridden from the `projectInfoVersion` key (which defaults to sbt's project version)
   version: "current"
-  jdk-versions: ["OpenJDK 8"]
+  jdk-versions: ["Eclipse Temurin OpenJDK 11"]
   title: "play-grpc"
   issues: {
     url: "https://github.com/playframework/play-grpc/issues"


### PR DESCRIPTION
### sun.security.x509.
This Play doc](https://www.playframework.com/documentation/2.9.x/Migration29#Generation-of-Self-Signed-Certificates-Fails-in-Java-17-and-Java-21) explains why we get the error in pipelines.

In fact, we set the https.port only in staging and so on,  but we do not have any valid certificate.

> In the process of binding an HTTPS port, Play typically generates a self-signed certificate as a default procedure. However, when using Java 17, this operation may lead to the following exception:

```scala
java.lang.IllegalAccessError: class com.typesafe.sslconfig.ssl.FakeKeyStore$ 
(in unnamed module @0x68c8dd0e) 
cannot access class sun.security.x509.X509CertInfo (in module java.base) 
because module java.base does not export sun.security.x509 to unnamed 
module @0x68c8dd0e (FakeKeyStore.scala:89)
com.typesafe.sslconfig.ssl.FakeKeyStore$.createSelfSignedCertificate(...
```
To solve this issue in production/staging we have to export a specific var:

```bash
    export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED";
```