### PR TITLE
Introduce 0.11.x branch

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,7 +5,7 @@ on:
 
   push:
     branches:
-      - main # Check branch after merge
+      - 0.11.x # Check branch after merge
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -2,7 +2,7 @@ name: Dependency Graph
 on:
   push:
     branches:
-      - main
+      - 0.11.x
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches: # Snapshots
-      - main
+      - 0.11.x
     tags: ["**"] # Releases
 
 jobs:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: release-drafter/release-drafter@v5
         with:
           name: "Play gRPC $RESOLVED_VERSION"
-          config-name: release-drafts/increasing-minor-version.yml # located in .github/ in the default branch within this or the .github repo
+          config-name: release-drafts/increasing-patch-version.yml # located in .github/ in the default branch within this or the .github repo
           commitish: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - main
+      - 0.11.x
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Let's continue making Scala 3 work in the `main` branch first, then backport that to the 0.11.x branch and then make everything work with outdated akka-http.