### PR TITLE
Revert "TEMPORARY comment out failing tests"

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -5,4 +5,4 @@ nav:
   - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
-    pekko-grpc-version: 1.0.1 # Sync with `sbt-pekko-grpc` in project/plugins.sbt
+    pekko-grpc-version: 1.0.2 # Sync with `sbt-pekko-grpc` in project/plugins.sbt

--- a/play-scalatest/src/test/scala/play/grpc/scalatest/PlayActionsScalaTestSpec.scala
+++ b/play-scalatest/src/test/scala/play/grpc/scalatest/PlayActionsScalaTestSpec.scala
@@ -64,11 +64,9 @@ class PlayActionsScalaTestSpec
       result.status must be(200)
       result.header("grpc-status") mustEqual Some(Status.Code.INVALID_ARGUMENT.value().toString)
     }
-    /*
     "work with a gRPC client" in withGrpcClient[GreeterServiceClient] { client: GreeterServiceClient =>
       val reply = client.sayHello(HelloRequest("Alice")).futureValue
       reply.message must be("Hello, Alice!")
     }
-     */
   }
 }

--- a/play-scalatest/src/test/scala/play/grpc/scalatest/PlayActionsScalaTestSpec.scala
+++ b/play-scalatest/src/test/scala/play/grpc/scalatest/PlayActionsScalaTestSpec.scala
@@ -64,9 +64,11 @@ class PlayActionsScalaTestSpec
       result.status must be(200)
       result.header("grpc-status") mustEqual Some(Status.Code.INVALID_ARGUMENT.value().toString)
     }
-    "work with a gRPC client" in withGrpcClient[GreeterServiceClient] { client: GreeterServiceClient =>
-      val reply = client.sayHello(HelloRequest("Alice")).futureValue
-      reply.message must be("Hello, Alice!")
+    "work with a gRPC client" in withGrpcClient[GreeterServiceClient] { (client: GreeterServiceClient) =>
+      {
+        val reply = client.sayHello(HelloRequest("Alice")).futureValue
+        reply.message must be("Hello, Alice!")
+      }
     }
   }
 }

--- a/play-scalatest/src/test/scala/play/grpc/scalatest/PlayScalaTestSpec.scala
+++ b/play-scalatest/src/test/scala/play/grpc/scalatest/PlayScalaTestSpec.scala
@@ -62,9 +62,11 @@ class PlayScalaTestSpec
       result.status must be(200)
       result.header("grpc-status") mustEqual Some(Status.Code.INVALID_ARGUMENT.value().toString)
     }
-    "work with a gRPC client" in withGrpcClient[GreeterServiceClient] { client: GreeterServiceClient =>
-      val reply = client.sayHello(HelloRequest("Alice")).futureValue
-      reply.message must be("Hello, Alice!")
+    "work with a gRPC client" in withGrpcClient[GreeterServiceClient] { (client: GreeterServiceClient) =>
+      {
+        val reply = client.sayHello(HelloRequest("Alice")).futureValue
+        reply.message must be("Hello, Alice!")
+      }
     }
   }
 }

--- a/play-scalatest/src/test/scala/play/grpc/scalatest/PlayScalaTestSpec.scala
+++ b/play-scalatest/src/test/scala/play/grpc/scalatest/PlayScalaTestSpec.scala
@@ -62,11 +62,9 @@ class PlayScalaTestSpec
       result.status must be(200)
       result.header("grpc-status") mustEqual Some(Status.Code.INVALID_ARGUMENT.value().toString)
     }
-    /*
     "work with a gRPC client" in withGrpcClient[GreeterServiceClient] { client: GreeterServiceClient =>
       val reply = client.sayHello(HelloRequest("Alice")).futureValue
       reply.message must be("Hello, Alice!")
     }
-     */
   }
 }

--- a/play-specs2/src/test/scala/play/grpc/specs2/PlaySpecs2Spec.scala
+++ b/play-specs2/src/test/scala/play/grpc/specs2/PlaySpecs2Spec.scala
@@ -64,13 +64,11 @@ class PlaySpecs2Spec extends ForServer with ServerGrpcClient with PlaySpecificat
         // grpc-status 3 means INVALID_ARGUMENT error. See https://developers.google.com/maps-booking/reference/grpc-api/status_codes
         result.header("grpc-status") must beSome(Status.Code.INVALID_ARGUMENT.value().toString)
     }
-    /*
     "work with a gRPC client" >> { implicit rs: RunningServer =>
       withGrpcClient[GreeterServiceClient] { client: GreeterServiceClient =>
         val reply = await(client.sayHello(HelloRequest("Alice")))
         reply.message must ===("Hello, Alice!")
       }
     }
-     */
   }
 }

--- a/play-specs2/src/test/scala/play/grpc/specs2/PlaySpecs2Spec.scala
+++ b/play-specs2/src/test/scala/play/grpc/specs2/PlaySpecs2Spec.scala
@@ -65,9 +65,11 @@ class PlaySpecs2Spec extends ForServer with ServerGrpcClient with PlaySpecificat
         result.header("grpc-status") must beSome(Status.Code.INVALID_ARGUMENT.value().toString)
     }
     "work with a gRPC client" >> { implicit rs: RunningServer =>
-      withGrpcClient[GreeterServiceClient] { client: GreeterServiceClient =>
-        val reply = await(client.sayHello(HelloRequest("Alice")))
-        reply.message must ===("Hello, Alice!")
+      withGrpcClient[GreeterServiceClient] { (client: GreeterServiceClient) =>
+        {
+          val reply = await(client.sayHello(HelloRequest("Alice")))
+          reply.message must ===("Hello, Alice!")
+        }
       }
     }
   }

--- a/play-testkit/src/test/java/play/grpc/testkit/PlayJavaFunctionalTest.java
+++ b/play-testkit/src/test/java/play/grpc/testkit/PlayJavaFunctionalTest.java
@@ -81,7 +81,6 @@ public final class PlayJavaFunctionalTest {
         rsp.getSingleHeader("grpc-status").get());
   }
 
-  /*
   @Test
   public void worksWithAGrpcClient() throws Exception {
 
@@ -100,5 +99,4 @@ public final class PlayJavaFunctionalTest {
       greeterServiceClient.close().toCompletableFuture().get(30, TimeUnit.SECONDS);
     }
   }
-  */
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,5 @@ addSbtPlugin("org.playframework.twirl" % "sbt-twirl"             % "2.0.3")
 addSbtPlugin("de.heikoseeberger"       % "sbt-header"            % "5.10.0")
 addSbtPlugin("org.scalameta"           % "sbt-scalafmt"          % "2.5.2")
 addSbtPlugin("com.lightbend.sbt"       % "sbt-java-formatter"    % "0.8.0")
-addSbtPlugin("org.apache.pekko"        % "pekko-grpc-sbt-plugin" % "1.0.1") // Sync with docs/antora.yml
+addSbtPlugin("org.apache.pekko"        % "pekko-grpc-sbt-plugin" % "1.0.2") // Sync with docs/antora.yml
 addSbtPlugin("com.github.sbt"          % "sbt-ci-release"        % "1.5.12")


### PR DESCRIPTION
This reverts commit 01c7d395fa80147d6b1ecea6b6f6e1132b95cd4c.

Of course needs a new release of pekko-grpc.

To run the affected tests:
```sbt
testOnly play.grpc.scalatest.PlayActionsScalaTestSpec play.grpc.scalatest.PlayScalaTestSpec play.grpc.specs2.PlaySpecs2Spec play.grpc.testkit.PlayJavaFunctionalTest
```