### PR TITLE
[0.11.x] Activate Scala 3 when using the Akka stack

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,7 +39,7 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 17, 11
-      scala: 2.13.x
+      scala: 3.x, 2.13.x
       cmd: sbt ++$MATRIX_SCALA test
 
   finish:

--- a/project/CommonPlugin.scala
+++ b/project/CommonPlugin.scala
@@ -10,6 +10,15 @@ import Dependencies.Versions.scala3
 object CommonPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
+  private val akkaDeps =
+    Seq("akka-actor", "akka-actor-typed", "akka-slf4j", "akka-serialization-jackson", "akka-stream", "akka-discovery")
+  private val scala2Deps = Map(
+    "com.typesafe.akka"            -> ("2.6.21", akkaDeps),
+    "com.typesafe"                 -> ("0.6.1", Seq("ssl-config-core")),
+    "com.fasterxml.jackson.module" -> ("2.14.3", Seq("jackson-module-scala")),
+    "org.scala-lang.modules"       -> ("xxx", Seq("scala-parser-combinators")),
+  )
+
   override def projectSettings = Seq(
     scalacOptions ++= {
       if (scalaVersionNumber.value.matchesSemVer(SemanticSelector("<=2.12")))
@@ -22,6 +31,13 @@ object CommonPlugin extends AutoPlugin {
     Test / fork        := true,
     crossScalaVersions := Seq(scala213, scala3),
     scalaVersion       := scala213,
+    // Work around needed because akka-http 10.2.x is not published for Scala 3
+    excludeDependencies ++=
+      (if (scalaBinaryVersion.value == "3") {
+         scala2Deps.flatMap(e => e._2._2.map(_ + "_3").map(ExclusionRule(e._1, _))).toSeq
+       } else {
+         Seq.empty
+       }),
   )
 
   val scalaVersionNumber = Def.setting(VersionNumber(scalaVersion.value))

--- a/project/CommonPlugin.scala
+++ b/project/CommonPlugin.scala
@@ -3,8 +3,8 @@ package build.play.grpc
 import sbt._
 import sbt.Keys._
 
-import Dependencies.Versions.scala212
 import Dependencies.Versions.scala213
+import Dependencies.Versions.scala3
 
 // WORKAROUND https://github.com/sbt/sbt/issues/2899
 object CommonPlugin extends AutoPlugin {
@@ -20,7 +20,7 @@ object CommonPlugin extends AutoPlugin {
     doc / javacOptions --= Seq("-Xlint:unchecked", "-Xlint:deprecation"),
     Test / javaOptions ++= Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED"),
     Test / fork        := true,
-    crossScalaVersions := Seq(scala213),
+    crossScalaVersions := Seq(scala213, scala3),
     scalaVersion       := scala213,
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,12 +40,18 @@ object Dependencies {
     val akkaPersistenceQuery     = "com.typesafe.akka" %% "akka-persistence-query"      % Versions.akka
     val akkaSerializationJackson = "com.typesafe.akka" %% "akka-serialization-jackson"  % Versions.akka
 
-    val akkaHttp          = "com.typesafe.akka" %% "akka-http"            % Versions.akkaHttp
-    val akkaHttpSprayJson = "com.typesafe.akka" %% "akka-http-spray-json" % Versions.akkaHttp
-    val akkaHttp2Support  = "com.typesafe.akka" %% "akka-http2-support"   % Versions.akkaHttp
+    val akkaHttp = ("com.typesafe.akka" %% "akka-http" % Versions.akkaHttp).cross(CrossVersion.for3Use2_13)
+    val akkaHttpSprayJson =
+      ("com.typesafe.akka" %% "akka-http-spray-json" % Versions.akkaHttp).cross(CrossVersion.for3Use2_13)
+    val akkaHttp2Support =
+      ("com.typesafe.akka" %% "akka-http2-support" % Versions.akkaHttp).cross(CrossVersion.for3Use2_13)
 
-    val akkaGrpcCodegen = "com.lightbend.akka.grpc" %% "akka-grpc-codegen" % Versions.akkaGrpc // Apache V2
-    val akkaGrpcRuntime = "com.lightbend.akka.grpc" %% "akka-grpc-runtime" % Versions.akkaGrpc // Apache V2
+    val akkaGrpcCodegen = ("com.lightbend.akka.grpc" %% "akka-grpc-codegen" % Versions.akkaGrpc).cross(
+      CrossVersion.for3Use2_13
+    ) // Apache V2
+    val akkaGrpcRuntime = ("com.lightbend.akka.grpc" %% "akka-grpc-runtime" % Versions.akkaGrpc).cross(
+      CrossVersion.for3Use2_13
+    ) // Apache V2
 
     val play = ("com.typesafe.play" %% "play" % Versions.play)
       .exclude("javax.activation", "javax.activation-api") // Apache V2 (exclusion is "either GPL or CDDL")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,6 +10,7 @@ object Dependencies {
   object Versions {
     val scala212 = "2.12.19"
     val scala213 = "2.13.14"
+    val scala3   = "3.3.3"
 
     // Don't use AkkaGrpcBuildInfo.akkaHttpVersion or AkkaGrpcBuildInfo.akkaVersion and prioritize
     // aligning with versions transitively brought in via Play.


### PR DESCRIPTION
A bit more tricky than on `main` branch because following dependencies do not provide Scala 3 artifacts:
```
com.lightbend.akka.grpc:akka-grpc-codegen:2.1.5
com.lightbend.akka.grpc:akka-grpc-runtime:2.1.5

com.typesafe.akka:akka-http-spray-json:10.2.10
com.typesafe.akka:akka-http2-support:10.2.10
com.typesafe.akka:akka-http:10.2.10
```