### PR TITLE
[0.11.x] Fix publish workflow once more

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,13 +7,13 @@ on:
     tags: ["**"] # Releases
 
 jobs:
-  publish-artifacts-2.13:
+  publish-artifacts-scala-2:
     name: Publish / Scala 2.13 Artifacts
     uses: playframework/.github/.github/workflows/publish.yml@v3
     with:
       cmd: CI_RELEASE=publishSigned sbt ++2.13.x ci-release
     secrets: inherit
-  publish-artifacts-3:
+  publish-artifacts-scala-3:
     name: Publish / Scala 3 Artifacts
     uses: playframework/.github/.github/workflows/publish.yml@v3
     with:


### PR DESCRIPTION
Fixes

> The workflow is not valid. .github/workflows/publish.yml (Line: 10, Col: 3): The identifier 'publish-artifacts-2.13' is invalid. IDs may only contain alphanumeric characters, '_', and '-'. IDs must start with a letter or '_' and and must be less than 100 characters.