### PR TITLE
Add support for HttpEntity.Strict in PlayRouterUsingActions

### DIFF
--- a/play-runtime/src/main/scala/play/grpc/internal/PlayRouterUsingActions.scala
+++ b/play-runtime/src/main/scala/play/grpc/internal/PlayRouterUsingActions.scala
@@ -127,6 +127,12 @@ import play.api.routing.Router.Routes
           case HttpEntity.Chunk(data, ext) => Chunk(data)
         }
         Chunked(playChunks, Some(ct.toString()))
+      case HttpEntity.Strict(ct, data) =>
+        val trailer = pekkoResp.attributes.get(AttributeKeys.trailer).collect { case t: Trailer => t }
+        val playChunks: Source[HttpChunk, Any] = Source(
+          Seq(Chunk(data), LastChunk(Headers(trailer.toSeq.flatMap(_.headers): _*)))
+        )
+        Chunked(playChunks, Some(ct.toString()))
       case e => throw new NotImplementedError(s"Unexpected response entity type: ${e.getClass.getName}")
     }
     Result(pekkoToPlayResponseHeaders(pekkoResp), playEntity)


### PR DESCRIPTION
There is a bug in PlayRouterUsingActions caused by changes to how unary methods are handled in akka-grpc. The offending commit appears to be https://github.com/apache/pekko-grpc/commit/fa341ccd42fd31fb73ff0e23af33aaefa0d9839c.

My changes have been tested and work with my use-case. I'd love to get some guidance on how to get this fully tested to the acceptance standards of the project, and get this published as a bugfix to the 0.12.x releases. I can help port the change to other versions if needed.

I'd also like to help document the usage of the `use_play_actions` code generator setting as I feel it is quite useful. 